### PR TITLE
gemspec to support building java only gem

### DIFF
--- a/fortitude.gemspec
+++ b/fortitude.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.extensions << "ext/fortitude_native_ext/extconf.rb"
+  if RUBY_PLATFORM =~ /java/
+    s.platform = 'java'
+  else
+    s.platform = Gem::Platform::RUBY
+    s.extensions << "ext/fortitude_native_ext/extconf.rb"
+  end
 
   activesupport_spec = if RUBY_VERSION =~ /^1\.8\./
     [ ">= 3.0", "< 4.0" ]


### PR DESCRIPTION
Disclaimer:
This is my limited understanding about this. I have internal gems using this style but none in rubygems.org.

I get error now when installing the gem on jruby. The message is at the bottom.
This is because of the c extension that is not used on jruby.

The common pattern I have seen is to make 2 versions of the same gem.
I think nokogiri uses this style.
Also json gem. json gem even has separate gemspec files for each version.
https://github.com/flori/json/blob/master/json-java.gemspec
https://github.com/flori/json/blob/master/json.gemspec
Notice the same 's.name = "json"' in both.

This pull request combined with the following workflow will result in 1 gem for mri ruby and 1 gem for jruby.
Example using rvm to  show the idea, but other tools work the same.

rvm ruby@fortitude
gem build fortitude.gemspec
rvm jruby@fortitude
gem build fortitude.gemspec
# now you should have 2 gems. one with *-java.gem ending.

gem push *.gem 

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /home/zizzler/.rvm/rubies/jruby-1.7.12/bin/jruby extconf.rb 
NotImplementedError: C extension support is not enabled. Pass -Xcext.enabled=true to JRuby or set JRUBY_OPTS.

   (root) at /home/zizzler/.rvm/rubies/jruby-1.7.12/lib/ruby/shared/mkmf.rb:8
  require at org/jruby/RubyKernel.java:1065
   (root) at /home/zizzler/.rvm/rubies/jruby-1.7.12/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1
   (root) at extconf.rb:1

extconf failed, uncaught signal 1

Gem files will remain installed in /home/zizzler/.rvm/gems/jruby-1.7.12@raami/gems/fortitude-0.0.3 for inspection.
Results logged to /home/zizzler/.rvm/gems/jruby-1.7.12@raami/extensions/universal-java-1.7/1.9/fortitude-0.0.3/gem_make.out
An error occurred while installing fortitude (0.0.3), and Bundler cannot
continue.
Make sure that `gem install fortitude -v '0.0.3'` succeeds before bundling.
```
