### PR TITLE
use `equal?` instead of `==` when checking value of need

### DIFF
--- a/lib/fortitude/method_templates/need_assignment_template.rb.smpl
+++ b/lib/fortitude/method_templates/need_assignment_template.rb.smpl
@@ -2,9 +2,9 @@
 @_fortitude_extra_assigns.delete(:#{need})           # :if [ :error, :use ].include?(extra_assigns)
 
 value = assigns.fetch(:#{need}, NOT_PRESENT_NEED)
-if value == NOT_PRESENT_NEED
+if value.equal?(NOT_PRESENT_NEED)
   value = assigns.fetch('#{need}', NOT_PRESENT_NEED)
-  if value == NOT_PRESENT_NEED
+  if value.equal?(NOT_PRESENT_NEED)
     value = nil                                      # :if ! has_default
     missing << :#{need}                              # :if ! has_default
     have_missing = true                              # :if ! has_default


### PR DESCRIPTION
You can tell me what you think of this, but I think it's safer to use `equal?` here and not worry about invoking any overloaded `==` operator.
