### PR TITLE
Use alias_method in place of alias_method_name

### DIFF
--- a/lib/fortitude/support/method_overriding.rb
+++ b/lib/fortitude/support/method_overriding.rb
@@ -62,7 +62,9 @@ EOS
 EOS
 
           target_module.send(:include, override_methods_module)
-          target_module.send(:alias_method_chain, method_name, feature_name)
+          # Below is equivalent to using alias_method_chain(method_name, feature_name)
+          target_module.send(:alias_method, without_name, method_name)
+          target_module.send(:alias_method, method_name, with_name)
         end
       end
 


### PR DESCRIPTION
Currently Fortitude still uses the `alias_method_chain` method instead of `Module#prepend` for old Ruby and JRuby.

At least when testing on JRuby 9.2.0.0, it still seems to have the issues mentioned in the comments where it stack overflows, as an interim solution I think we just replace it with equivalent code so Rails 5+ can be used.